### PR TITLE
Version 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,113 @@
 [![travis-image]][travis]
 [![pypi-image]][pypi]
 
+## Introduction
+
+This is a Python [Core API][coreapi] codec for the [Open API][openapi] schema format, also known as "Swagger".
+
 ## Installation
 
 Install using pip:
 
     $ pip install openapi-codec
 
+## Creating Swagger schemas
+
+To create a swagger schema from a `coreapi.Document`, use the codec directly.
+
+    >>> from openapi_codec import OpenAPICodec
+    >>> codec = OpenAPICodec()
+    >>> schema = codec.encode(document)
+
+## Using with the Python Client Library
+
+To use the Python client library to interact with a service that exposes a Swagger schema,
+include the codec in [the `decoders` argument][decoders].
+
+    >>> from openapi_codec import OpenAPICodec
+    >>> from coreapi.codecs import JSONCodec
+    >>> from coreapi import Client
+    >>> decoders = [OpenAPICodec(), JSONCodec()]
+    >>> client = Client(decoders=decoders)
+
+If the server exposes the schema without properly using an `application/openapi+json` content type, then you'll need to make sure to include `format='openapi'` on the initial request,
+to force the correct codec to be used.
+
+    >>> schema = client.get('http://petstore.swagger.io/v2/swagger.json', format='openapi')
+
+At this point you can now start to interact with the API:
+
+    >>> client.action(schema, ['pet', 'addPet'], params={'photoUrls': [], 'name': 'fluffy'})
+
+## Using with the Command Line Client
+
+Once the `openapi-codec` package is installed, the codec will automatically become available to the command line client.
+
+    $ pip install coreapi-cli openapi-codec
+    $ coreapi codecs show
+    Codec name   Media type                 Support              Package
+    corejson   | application/coreapi+json | encoding, decoding | coreapi==2.0.7
+    openapi    | application/openapi+json | encoding, decoding | openapi-codec==1.1.0
+    json       | application/json         | decoding           | coreapi==2.0.7
+    text       | text/*                   | decoding           | coreapi==2.0.7
+    download   | */*                      | decoding           | coreapi==2.0.7
+
+If the server exposes the schema without properly using an `application/openapi+json` content type, then you'll need to make sure to include `format=openapi` on the initial request, to force the correct codec to be used.
+
+    $ coreapi get http://petstore.swagger.io/v2/swagger.json --format openapi
+    <Swagger Petstore "http://petstore.swagger.io/v2/swagger.json">
+        pet: {
+            addPet(photoUrls, name, [status], [id], [category], [tags])
+            deletePet(petId, [api_key])
+            findPetsByStatus(status)
+            ...
+
+At this point you can start to interact with the API.
+
+    $ coreapi action pet addPet --param name=fluffy --param photoUrls=[]
+    {
+        "id": 201609262739,
+        "name": "fluffy",
+        "photoUrls": [],
+        "tags": []
+    }
+
+Use the `--debug` flag to see the full HTTP request and response.
+
+    $ coreapi action pet addPet --param name=fluffy --param photoUrls=[] --debug
+    > POST /v2/pet HTTP/1.1
+    > Accept-Encoding: gzip, deflate
+    > Connection: keep-alive
+    > Content-Length: 35
+    > Content-Type: application/json
+    > Accept: application/coreapi+json, */*
+    > Host: petstore.swagger.io
+    > User-Agent: coreapi
+    >
+    > {"photoUrls": [], "name": "fluffy"}
+    < 200 OK
+    < Access-Control-Allow-Headers: Content-Type, api_key, Authorization
+    < Access-Control-Allow-Methods: GET, POST, DELETE, PUT
+    < Access-Control-Allow-Origin: *
+    < Connection: close
+    < Content-Type: application/json
+    < Date: Mon, 26 Sep 2016 13:17:33 GMT
+    < Server: Jetty(9.2.9.v20150224)
+    <
+    < {"id":201609262739,"name":"fluffy","photoUrls":[],"tags":[]}
+
+    {
+        "id": 201609262739,
+        "name": "fluffy",
+        "photoUrls": [],
+        "tags": []
+    }
 
 [travis-image]: https://secure.travis-ci.org/core-api/python-openapi-codec.svg?branch=master
 [travis]: http://travis-ci.org/core-api/python-openapi-codec?branch=master
 [pypi-image]: https://img.shields.io/pypi/v/openapi-codec.svg
 [pypi]: https://pypi.python.org/pypi/openapi-codec
+
+[coreapi]: http://www.coreapi.org/
+[openapi]: https://openapis.org/
+[decoders]: http://core-api.github.io/python-client/api-guide/client/#instantiating-a-client

--- a/openapi_codec/__init__.py
+++ b/openapi_codec/__init__.py
@@ -8,11 +8,12 @@ from openapi_codec.encode import generate_swagger_object
 from openapi_codec.decode import _parse_document
 
 
-__version__ = "1.1.0"
+__version__ = '1.1.0'
 
 
 class OpenAPICodec(BaseCodec):
-    media_type = "application/openapi+json"
+    media_type = 'application/openapi+json'
+    format = 'openapi'
 
     def decode(self, bytes, **options):
         """

--- a/openapi_codec/__init__.py
+++ b/openapi_codec/__init__.py
@@ -8,7 +8,7 @@ from openapi_codec.encode import generate_swagger_object
 from openapi_codec.decode import _parse_document
 
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 
 class OpenAPICodec(BaseCodec):

--- a/openapi_codec/__init__.py
+++ b/openapi_codec/__init__.py
@@ -13,7 +13,6 @@ __version__ = "1.1.0"
 
 class OpenAPICodec(BaseCodec):
     media_type = "application/openapi+json"
-    supports = ['encoding', 'decoding']
 
     def decode(self, bytes, **options):
         """

--- a/openapi_codec/__init__.py
+++ b/openapi_codec/__init__.py
@@ -15,7 +15,7 @@ class OpenAPICodec(BaseCodec):
     media_type = "application/openapi+json"
     supports = ['encoding', 'decoding']
 
-    def load(self, bytes, base_url=None):
+    def decode(self, bytes, **options):
         """
         Takes a bytestring and returns a document.
         """
@@ -24,12 +24,15 @@ class OpenAPICodec(BaseCodec):
         except ValueError as exc:
             raise ParseError('Malformed JSON. %s' % exc)
 
+        base_url = options.get('base_url')
         doc = _parse_document(data, base_url)
         if not isinstance(doc, Document):
             raise ParseError('Top level node must be a document.')
 
         return doc
 
-    def dump(self, document, **kwargs):
+    def encode(self, document, **options):
+        if not isinstance(document, coreapi.Document):
+            raise ValueError('Expected a `coreapi.Document` instance')
         data = generate_swagger_object(document)
         return force_bytes(json.dumps(data))

--- a/openapi_codec/__init__.py
+++ b/openapi_codec/__init__.py
@@ -32,6 +32,6 @@ class OpenAPICodec(BaseCodec):
 
     def encode(self, document, **options):
         if not isinstance(document, Document):
-            raise ValueError('Expected a `coreapi.Document` instance')
+            raise TypeError('Expected a `coreapi.Document` instance')
         data = generate_swagger_object(document)
         return force_bytes(json.dumps(data))

--- a/openapi_codec/__init__.py
+++ b/openapi_codec/__init__.py
@@ -32,7 +32,7 @@ class OpenAPICodec(BaseCodec):
         return doc
 
     def encode(self, document, **options):
-        if not isinstance(document, coreapi.Document):
+        if not isinstance(document, Document):
             raise ValueError('Expected a `coreapi.Document` instance')
         data = generate_swagger_object(document)
         return force_bytes(json.dumps(data))

--- a/openapi_codec/decode.py
+++ b/openapi_codec/decode.py
@@ -12,7 +12,7 @@ def _parse_document(data, base_url=None):
     paths = _get_dict(data, 'paths')
     content = {}
     for path in paths.keys():
-        url = urlparse.urljoin(base_url, path.lstrip('/'))
+        url = base_url + path.lstrip('/')
         spec = _get_dict(paths, path)
         default_parameters = get_dicts(_get_list(spec, 'parameters'))
         for action in spec.keys():
@@ -83,7 +83,7 @@ def _get_document_base_url(data, base_url=None):
     Get the base url to use when constructing absolute paths from the
     relative ones provided in the schema defination.
     """
-    prefered_schemes = ['http', 'https']
+    prefered_schemes = ['https', 'http']
     if base_url:
         url_components = urlparse.urlparse(base_url)
         default_host = url_components.netloc

--- a/openapi_codec/decode.py
+++ b/openapi_codec/decode.py
@@ -43,7 +43,7 @@ def _parse_document(data, base_url=None):
                         expanded_fields = [
                             Field(name=field_name, location='form', required=is_required, description=field_description)
                             for field_name, is_required, field_description in expanded
-                            if not any([field.name == name for field in fields])
+                            if not any([field.name == field_name for field in fields])
                         ]
                         fields += expanded_fields
                     else:

--- a/openapi_codec/decode.py
+++ b/openapi_codec/decode.py
@@ -68,10 +68,13 @@ def _parse_document(data, base_url=None):
             tags = get_strings(_get_list(operation, 'tags'))
             operation_id = _get_string(operation, 'operationId')
             if tags:
-                for tag in tags:
-                    if tag not in content:
-                        content[tag] = {}
-                    content[tag][operation_id] = link
+                tag = tags[0]
+                prefix = tag + '_'
+                if operation_id.startswith(prefix):
+                    operation_id = operation_id[len(prefix):]
+                if tag not in content:
+                    content[tag] = {}
+                content[tag][operation_id] = link
             else:
                 content[operation_id] = link
 

--- a/openapi_codec/encode.py
+++ b/openapi_codec/encode.py
@@ -10,17 +10,13 @@ def generate_swagger_object(document):
 
     return {
         'swagger': '2.0',
-        'info': _get_info_object(document),
+        'info': {
+            'title': document.title,
+            'version': ''  # Required by the spec
+        },
         'paths': _get_paths_object(document),
         'host': parsed_url.netloc,
         'schemes': [parsed_url.scheme]
-    }
-
-
-def _get_info_object(document):
-    return {
-        'title': document.title,
-        'version': ''  # Required by the spec
     }
 
 
@@ -142,8 +138,8 @@ def _get_responses(link):
     on action / method type.
     """
     template = {'description': ''}
-    if link.action == 'post':
+    if link.action.lower() == 'post':
         return {'201': template}
-    if link.action == 'delete':
+    if link.action.lower() == 'delete':
         return {'204': template}
     return {'200': template}

--- a/openapi_codec/encode.py
+++ b/openapi_codec/encode.py
@@ -80,6 +80,7 @@ def _get_parameters(link, encoding):
         location = get_location(link, field)
         if location == 'form':
             if encoding in ('multipart/form-data', 'application/x-www-form-urlencoded'):
+                # 'formData' in swagger MUST be one of these media types.
                 parameter = {
                     'name': field.name,
                     'required': field.required,
@@ -89,6 +90,8 @@ def _get_parameters(link, encoding):
                 }
                 parameters.append(parameter)
             else:
+                # Expand coreapi fields with location='form' into a single swagger
+                # parameter, with a schema containing multiple properties.
                 schema_property = {
                     'description': field.description
                 }
@@ -131,13 +134,6 @@ def _get_parameters(link, encoding):
         })
 
     return parameters
-
-
-def _get_in(link, field):
-    in_location = get_location(link, field)
-    if in_location == 'form':
-        return 'formData'
-    return in_location
 
 
 def _get_responses(link):

--- a/openapi_codec/encode.py
+++ b/openapi_codec/encode.py
@@ -32,8 +32,9 @@ def _get_paths_object(document):
             if link.url not in paths:
                 paths[link.url] = {}
 
+            method = link.action.lower() or 'get'
             operation = _get_operation(tag, link)
-            paths[link.url].update({link.action: operation})
+            paths[link.url].update({method: operation})
 
     return paths
 
@@ -45,7 +46,6 @@ def _get_operation(tag, link):
         'responses': _get_responses(link),
         'parameters': _get_parameters(link.fields)
     }
-
 
 def _get_parameters(fields):
     """

--- a/openapi_codec/encode.py
+++ b/openapi_codec/encode.py
@@ -1,4 +1,5 @@
 from coreapi.compat import urlparse
+from openapi_codec.utils import get_method, get_encoding, get_location
 
 
 def generate_swagger_object(document):
@@ -12,6 +13,7 @@ def generate_swagger_object(document):
         'info': _get_info_object(document),
         'paths': _get_paths_object(document),
         'host': parsed_url.netloc,
+        'schemes': [parsed_url.scheme]
     }
 
 
@@ -24,49 +26,118 @@ def _get_info_object(document):
 
 def _get_paths_object(document):
     paths = {}
+
+    # Top-level links. We do not include a swagger 'tag' for these.
+    for operation_id, link in document.links.items():
+        if link.url not in paths:
+            paths[link.url] = {}
+
+        method = get_method(link)
+        operation = _get_operation(link, operation_id)
+        paths[link.url].update({method: operation})
+
+    # Second-level links. We include a swagger 'tag' for these.
     for tag, object_ in document.data.items():
         if not hasattr(object_, 'links'):
             continue
 
-        for link in object_.links.values():
+        for operation_id, link in object_.links.items():
             if link.url not in paths:
                 paths[link.url] = {}
 
-            method = link.action.lower() or 'get'
-            operation = _get_operation(tag, link)
+            method = get_method(link)
+            operation = _get_operation(link, operation_id, tags=[tag])
             paths[link.url].update({method: operation})
 
     return paths
 
 
-def _get_operation(tag, link):
-    return {
-        'tags': [tag],
+def _get_operation(link, operation_id, tags=None):
+    encoding = get_encoding(link)
+
+    operation = {
+        'operationId': operation_id,
         'description': link.description,
         'responses': _get_responses(link),
-        'parameters': _get_parameters(link.fields)
+        'parameters': _get_parameters(link, encoding)
     }
+    if encoding:
+        operation['consumes'] = [encoding]
+    if tags:
+        operation['tags'] = tags
+    return operation
 
-def _get_parameters(fields):
+
+def _get_parameters(link, encoding):
     """
     Generates Swagger Parameter Item object.
     """
-    return [
-        {
-            'name': field.name,
-            'required': field.required,
-            'in': _convert_location_to_in(field),
-            'description': field.description,
-            'type': 'string'
-        }
-        for field in fields
-    ]
+    parameters = []
+    properties = {}
+    required = []
+
+    for field in link.fields:
+        location = get_location(link, field)
+        if location == 'form':
+            if encoding in ('multipart/form-data', 'application/x-www-form-urlencoded'):
+                parameter = {
+                    'name': field.name,
+                    'required': field.required,
+                    'in': 'formData',
+                    'description': field.description,
+                    'type': 'string'
+                }
+                parameters.append(parameter)
+            else:
+                schema_property = {
+                    'description': field.description
+                }
+                properties[field.name] = schema_property
+                if field.required:
+                    required.append(field.name)
+        elif location == 'body':
+            if encoding == 'application/octet-stream':
+                # https://github.com/OAI/OpenAPI-Specification/issues/50#issuecomment-112063782
+                schema = {'type': 'string', 'format': 'binary'}
+            else:
+                schema = {}
+            parameter = {
+                'name': field.name,
+                'required': field.required,
+                'in': location,
+                'description': field.description,
+                'schema': schema
+            }
+            parameters.append(parameter)
+        else:
+            parameter = {
+                'name': field.name,
+                'required': field.required,
+                'in': location,
+                'description': field.description,
+                'type': 'string'
+            }
+            parameters.append(parameter)
+
+    if properties:
+        parameters.append({
+            'name': 'data',
+            'in': 'body',
+            'schema': {
+                'type': 'object',
+                'properties': properties,
+                'required': required
+            }
+        })
+
+    return parameters
 
 
-def _convert_location_to_in(field):
-    if field.location == 'form':
+def _get_in(link, field):
+    in_location = get_location(link, field)
+    if in_location == 'form':
         return 'formData'
-    return field.location
+    return in_location
 
 
 def _get_responses(link):

--- a/openapi_codec/utils.py
+++ b/openapi_codec/utils.py
@@ -1,0 +1,25 @@
+def get_method(link):
+    method = link.action.lower()
+    if not method:
+        method = 'get'
+    return method
+
+
+def get_encoding(link):
+    encoding = link.encoding
+    has_body = any([get_location(link, field) in ('form', 'body') for field in link.fields])
+    if not encoding and has_body:
+        encoding = 'application/json'
+    elif encoding and not has_body:
+        encoding = ''
+    return encoding
+
+
+def get_location(link, field):
+    location = field.location
+    if not location:
+        if get_method(link) in ('get', 'delete'):
+            location = 'query'
+        else:
+            location = 'form'
+    return location

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -59,6 +59,7 @@ class TestPaths(TestCase):
             },
             'parameters': [],
             'description': '',
+            'operationId': 'list',
             'tags': ['users']
         }
         self.assertEquals(self.swagger['paths'][self.path]['get'], expected)
@@ -70,6 +71,7 @@ class TestPaths(TestCase):
             },
             'parameters': [],
             'description': '',
+            'operationId': 'create',
             'tags': ['users']
         }
         self.assertEquals(self.swagger['paths'][self.path]['post'], expected)
@@ -83,7 +85,7 @@ class TestParameters(TestCase):
             location='query',
             description='A valid email address.'
         )
-        self.swagger = _get_parameters([self.field])
+        self.swagger = _get_parameters(coreapi.Link(fields=[self.field]), encoding='')
 
     def test_expected_fields(self):
         self.assertEquals(len(self.swagger), 1)

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -1,0 +1,196 @@
+from openapi_codec import OpenAPICodec
+import coreapi
+
+
+codec = OpenAPICodec()
+doc = coreapi.Document(
+    url='https://api.example.com/',
+    title='Example API',
+    content={
+        'simple_link': coreapi.Link('/simple_link/', description='example link'),
+        'location': {
+            'query': coreapi.Link('/location/query/', fields=[
+                coreapi.Field(name='a', description='example field', required=True),
+                coreapi.Field(name='b')
+            ]),
+            'form': coreapi.Link('/location/form/', action='post', fields=[
+                coreapi.Field(name='a', description='example field', required=True),
+                coreapi.Field(name='b'),
+            ]),
+            'body': coreapi.Link('/location/body/', action='post', fields=[
+                coreapi.Field(name='example', location='body', description='example field')
+            ]),
+            'path': coreapi.Link('/location/path/{id}/', fields=[
+                coreapi.Field(name='id', location='path', required=True)
+            ])
+        },
+        'encoding': {
+            'multipart': coreapi.Link('/encoding/multipart/', action='post', encoding='multipart/form-data', fields=[
+                coreapi.Field(name='a', required=True),
+                coreapi.Field(name='b')
+            ]),
+            'multipart-body': coreapi.Link('/encoding/multipart-body/', action='post', encoding='multipart/form-data', fields=[
+                coreapi.Field(name='example', location='body')
+            ]),
+            'urlencoded': coreapi.Link('/encoding/urlencoded/', action='post', encoding='application/x-www-form-urlencoded', fields=[
+                coreapi.Field(name='a', required=True),
+                coreapi.Field(name='b')
+            ]),
+            'urlencoded-body': coreapi.Link('/encoding/urlencoded-body/', action='post', encoding='application/x-www-form-urlencoded', fields=[
+                coreapi.Field(name='example', location='body')
+            ]),
+            'upload': coreapi.Link('/encoding/upload/', action='post', encoding='application/octet-stream', fields=[
+                coreapi.Field(name='example', location='body', required=True)
+            ]),
+        }
+    }
+)
+
+
+def test_mapping():
+    """
+    Ensure that a document that is encoded into OpenAPI and then decoded
+    comes back as expected.
+    """
+    content = codec.dump(doc)
+    new = codec.load(content)
+    assert new.title == 'Example API'
+
+    assert new['simple_link'] == coreapi.Link(
+        url='https://api.example.com/simple_link/',
+        action='get',
+        description='example link'
+    )
+
+    assert new['location']['query'] == coreapi.Link(
+        url='https://api.example.com/location/query/',
+        action='get',
+        fields=[
+            coreapi.Field(
+                name='a',
+                location='query',
+                description='example field',
+                required=True
+            ),
+            coreapi.Field(
+                name='b',
+                location='query'
+            )
+        ]
+    )
+
+    assert new['location']['path'] == coreapi.Link(
+        url='https://api.example.com/location/path/{id}/',
+        action='get',
+        fields=[
+            coreapi.Field(
+                name='id',
+                location='path',
+                required=True
+            )
+        ]
+    )
+
+    assert new['location']['form'] == coreapi.Link(
+        url='https://api.example.com/location/form/',
+        action='post',
+        encoding='application/json',
+        fields=[
+            coreapi.Field(
+                name='a',
+                location='form',
+                required=True,
+                description='example field'
+            ),
+            coreapi.Field(
+                name='b',
+                location='form'
+            )
+        ]
+    )
+
+    assert new['location']['body'] == coreapi.Link(
+        url='https://api.example.com/location/body/',
+        action='post',
+        encoding='application/json',
+        fields=[
+            coreapi.Field(
+                name='example',
+                location='body',
+                description='example field'
+            )
+        ]
+    )
+
+    assert new['encoding']['multipart'] == coreapi.Link(
+        url='https://api.example.com/encoding/multipart/',
+        action='post',
+        encoding='multipart/form-data',
+        fields=[
+            coreapi.Field(
+                name='a',
+                location='form',
+                required=True
+            ),
+            coreapi.Field(
+                name='b',
+                location='form'
+            )
+        ]
+    )
+
+    assert new['encoding']['urlencoded'] == coreapi.Link(
+        url='https://api.example.com/encoding/urlencoded/',
+        action='post',
+        encoding='application/x-www-form-urlencoded',
+        fields=[
+            coreapi.Field(
+                name='a',
+                location='form',
+                required=True
+            ),
+            coreapi.Field(
+                name='b',
+                location='form'
+            )
+        ]
+    )
+
+    assert new['encoding']['upload'] == coreapi.Link(
+        url='https://api.example.com/encoding/upload/',
+        action='post',
+        encoding='application/octet-stream',
+        fields=[
+            coreapi.Field(
+                name='example',
+                location='body',
+                required=True
+            )
+        ]
+    )
+
+    # Swagger doesn't really support form data in the body, but we
+    # map it onto something reasonable anyway.
+    assert new['encoding']['multipart-body'] == coreapi.Link(
+        url='https://api.example.com/encoding/multipart-body/',
+        action='post',
+        encoding='multipart/form-data',
+        fields=[
+            coreapi.Field(
+                name='example',
+                location='body'
+            )
+        ]
+    )
+
+    assert new['encoding']['urlencoded-body'] == coreapi.Link(
+        url='https://api.example.com/encoding/urlencoded-body/',
+        action='post',
+        encoding='application/x-www-form-urlencoded',
+        fields=[
+            coreapi.Field(
+                name='example',
+                location='body'
+            )
+        ]
+    )


### PR DESCRIPTION
Still remaining:
- [x] Drop `supports`
- [x] `load()`/`dump()` -> `decode()`/`encode()`
- [x] Test against Pet Store API.
- [x] Documentation.
- [x] Review `basePath` vs `Document.url` usage throughout.
- [x] Resolve #8.
- [x] Review `operationId`/`tags` & ensure `operationId` is unique.
