### PR TITLE
Add additional key for items of type array in order to make swagger spec valid

### DIFF
--- a/openapi_codec/encode.py
+++ b/openapi_codec/encode.py
@@ -115,16 +115,20 @@ def _get_parameters(link, encoding):
                     'required': field.required,
                     'in': 'formData',
                     'description': field.description,
-                    'type': field.type or 'string'
+                    'type': field.type or 'string',
                 }
+                if field.type == 'array':
+                    parameter['items'] = {'type': 'string'}
                 parameters.append(parameter)
             else:
                 # Expand coreapi fields with location='form' into a single swagger
                 # parameter, with a schema containing multiple properties.
                 schema_property = {
                     'description': field.description,
-                    'type': field.type or 'string'
+                    'type': field.type or 'string',
                 }
+                if field.type == 'array':
+                    schema_property['items'] = {'type': 'string'}
                 properties[field.name] = schema_property
                 if field.required:
                     required.append(field.name)
@@ -148,8 +152,10 @@ def _get_parameters(link, encoding):
                 'required': field.required,
                 'in': location,
                 'description': field.description,
-                'type': field.type or 'string'
+                'type': field.type or 'string',
             }
+            if field.type == 'array':
+                parameter['items'] = {'type': 'string'}
             parameters.append(parameter)
 
     if properties:


### PR DESCRIPTION
Add additional key for items of type array with the type of each element we will default to 'string' right now in order to make our swagger spec
valid.

---

Closes #20 
