### PR TITLE
Graceful handling of 'file' fields in JSON links.

### DIFF
--- a/openapi_codec/__init__.py
+++ b/openapi_codec/__init__.py
@@ -8,7 +8,7 @@ from openapi_codec.encode import generate_swagger_object
 from openapi_codec.decode import _parse_document
 
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 
 class OpenAPICodec(BaseCodec):

--- a/openapi_codec/encode.py
+++ b/openapi_codec/encode.py
@@ -123,9 +123,13 @@ def _get_parameters(link, encoding):
             else:
                 # Expand coreapi fields with location='form' into a single swagger
                 # parameter, with a schema containing multiple properties.
+                use_type = field.type or 'string'
+                if use_type == 'file':
+                    use_type = 'string'
+
                 schema_property = {
                     'description': field.description,
-                    'type': field.type or 'string',
+                    'type': use_type,
                 }
                 if field.type == 'array':
                     schema_property['items'] = {'type': 'string'}


### PR DESCRIPTION
`type='file'` isn't really valid with `encoding="application/json"`.
In order to ensure that we still produce valid output we coerce these to "string" instead.