### PR TITLE
Add OpenAPI info.description field

### DIFF
--- a/openapi_codec/encode.py
+++ b/openapi_codec/encode.py
@@ -15,6 +15,7 @@ def generate_swagger_object(document):
     swagger['swagger'] = '2.0'
     swagger['info'] = OrderedDict()
     swagger['info']['title'] = document.title
+    swagger['info']['description'] = document.description
     swagger['info']['version'] = ''  # Required by the spec
 
     if parsed_url.netloc:

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -6,14 +6,19 @@ from unittest import TestCase
 
 class TestBasicInfo(TestCase):
     def setUp(self):
-        self.document = coreapi.Document(title='Example API', url='https://www.example.com/')
+        self.document = coreapi.Document(
+            title='Example API',
+            url='https://www.example.com/',
+            description='Example description.',
+        )
         self.swagger = generate_swagger_object(self.document)
 
     def test_info(self):
         self.assertIn('info', self.swagger)
         expected = {
             'title': self.document.title,
-            'version': ''
+            'version': '',
+            'description': self.document.description,
         }
         self.assertEquals(self.swagger['info'], expected)
 


### PR DESCRIPTION
The CoreAPI document now contains a `description`, so add it
to the OpenAPI `info` dictionary.

Fixes: https://github.com/core-api/python-openapi-codec/issues/34