### PR TITLE
Allow to encode custom attributes dict on Field object and Link

### DIFF
--- a/openapi_codec/encode.py
+++ b/openapi_codec/encode.py
@@ -79,7 +79,7 @@ def _get_paths_object(document):
 def _get_operation(operation_id, link, tags):
     encoding = get_encoding(link)
     description = link.description.strip()
-    custom_attributes = link.custom_attributes
+    custom_attributes = getattr(link, 'custom_attributes', None)
     summary = description.splitlines()[0] if description else None
 
     operation = {


### PR DESCRIPTION
This pull request is in complement with this one on the core-api library: https://github.com/core-api/python-client/pull/136.

If custom-attributes are set on the Link object or Field named tuple, we flatten them on the representation of it 