### PR TITLE
Support the API description from schema’s document

### DIFF
--- a/openapi_codec/encode.py
+++ b/openapi_codec/encode.py
@@ -16,6 +16,7 @@ def generate_swagger_object(document):
     swagger['info'] = OrderedDict()
     swagger['info']['title'] = document.title
     swagger['info']['version'] = ''  # Required by the spec
+    swagger['info']['description'] = document.description
 
     if parsed_url.netloc:
         swagger['host'] = parsed_url.netloc

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -13,7 +13,8 @@ class TestBasicInfo(TestCase):
         self.assertIn('info', self.swagger)
         expected = {
             'title': self.document.title,
-            'version': ''
+            'version': '',
+            'description': ''
         }
         self.assertEquals(self.swagger['info'], expected)
 
@@ -31,6 +32,21 @@ class TestBasicInfo(TestCase):
         self.assertIn('schemes', self.swagger)
         expected = ['https']
         self.assertEquals(self.swagger['schemes'], expected)
+
+
+class TestInfoDescription(TestCase):
+    def setUp(self):
+        self.document = coreapi.Document(title='Example API', url='https://www.example.com/', description='Welcome to API Docs')
+        self.swagger = generate_swagger_object(self.document)
+
+    def test_info(self):
+        self.assertIn('info', self.swagger)
+        expected = {
+            'title': self.document.title,
+            'version': '',
+            'description': self.document.description
+        }
+        self.assertEquals(self.swagger['info'], expected)
 
 
 class TestPaths(TestCase):


### PR DESCRIPTION
The swagger specification has a field called `description` that is used to display content at the top of a swagger page.

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#info-object

The description field is available in the coreapi Document:

https://github.com/core-api/python-client/blob/master/coreapi/document.py#L80

Please let me know if you have any questions!

Thank you,
Nick