### PR TITLE
Fill parameter name from Link object instead of using "data"

### DIFF
--- a/openapi_codec/encode.py
+++ b/openapi_codec/encode.py
@@ -1,7 +1,7 @@
 import coreschema
 from collections import OrderedDict
 from coreapi.compat import urlparse
-from openapi_codec.utils import get_method, get_encoding, get_location, get_links_from_document
+from openapi_codec.utils import get_method, get_encoding, get_location, get_links_from_document, get_parameter_name
 
 
 def generate_swagger_object(document):
@@ -193,8 +193,9 @@ def _get_parameters(link, encoding):
             parameters.append(parameter)
 
     if properties:
+        parameter_name = get_parameter_name(link)
         parameter = {
-            'name': 'data',
+            'name': parameter_name,
             'in': 'body',
             'schema': {
                 'type': 'object',

--- a/openapi_codec/utils.py
+++ b/openapi_codec/utils.py
@@ -30,6 +30,10 @@ def get_method(link):
     return method
 
 
+def get_parameter_name(link):
+    return link.title.title() + link.action.title() + "Params"
+
+
 def get_encoding(link):
     encoding = link.encoding
     has_body = any([get_location(link, field) in ('form', 'body') for field in link.fields])


### PR DESCRIPTION
As described by core-api/python-openapi-codec#28, the "name" field of the generated Swagger JSON is currently hard-coded to "data".  When using swagger-codegen, the generated models are labeled \<Data*\> which breaks the reusability of the generated SDKs.  

The proposed solution allows a user to set a "title" property on a view (or viewset) which is then used to generate the "name" field in this format:  \<Title\>\<Action\>Params.  

For example, the "post" action of the following viewset will be given a name of "CommentPostParams" instead of "data".

```python
class CommentViewSet(viewsets.ModelViewSet):
    queryset = Comment.objects.all()
    serializer_class = CommentSerializer
    title = "comment"
```

This pull request has an associated pull request at encode/django-rest-framework#5275, both of which act to drive further discussion on core-api/python-openapi-codec#28.  

Assuming views and viewsets are named \<ViewName\>View and \<ViewSetName\>ViewSet, it would also be possible to extract the view name automatically with a small code change.

Related issue: marcgibbons/django-rest-swagger#595